### PR TITLE
Fix error when playgrounds are compiled with Swift 6's default MainActor isolation setting

### DIFF
--- a/Sources/PlaygroundMacros/PlaygroundMacro.swift
+++ b/Sources/PlaygroundMacros/PlaygroundMacro.swift
@@ -97,7 +97,7 @@ public enum Playground: DeclarationMacro, Sendable {
       @_used
       #endif
       @available(*, deprecated, message: "This property is an implementation detail of the playgrounds library. Do not use it directly.")
-      private let \(playgroundContentRecordName): Playgrounds.__PlaygroundsContentRecord = (
+      nonisolated private let \(playgroundContentRecordName): Playgrounds.__PlaygroundsContentRecord = (
         0x706c6179, /* 'play' */
         0,
         { outValue, type, hint, _ in

--- a/Tests/PlaygroundMacrosTests/PlaygroundMacroExpansionTests.swift
+++ b/Tests/PlaygroundMacrosTests/PlaygroundMacroExpansionTests.swift
@@ -77,7 +77,7 @@ struct PlaygroundMacroExpansionTests {
       @_used
       #endif
       @available(*, deprecated, message: "This property is an implementation detail of the playgrounds library. Do not use it directly.")
-      private let __macro_local_23PlaygroundContentRecordfMu_: Playgrounds.__PlaygroundsContentRecord = (
+      nonisolated private let __macro_local_23PlaygroundContentRecordfMu_: Playgrounds.__PlaygroundsContentRecord = (
         0x706c6179, /* 'play' */
         0,
         { outValue, type, hint, _ in
@@ -159,7 +159,7 @@ struct PlaygroundMacroExpansionTests {
       @_used
       #endif
       @available(*, deprecated, message: "This property is an implementation detail of the playgrounds library. Do not use it directly.")
-      private let __macro_local_23PlaygroundContentRecordfMu_: Playgrounds.__PlaygroundsContentRecord = (
+      nonisolated private let __macro_local_23PlaygroundContentRecordfMu_: Playgrounds.__PlaygroundsContentRecord = (
         0x706c6179, /* 'play' */
         0,
         { outValue, type, hint, _ in
@@ -241,7 +241,7 @@ struct PlaygroundMacroExpansionTests {
       @_used
       #endif
       @available(*, deprecated, message: "This property is an implementation detail of the playgrounds library. Do not use it directly.")
-      private let __macro_local_23PlaygroundContentRecordfMu_: Playgrounds.__PlaygroundsContentRecord = (
+      nonisolated private let __macro_local_23PlaygroundContentRecordfMu_: Playgrounds.__PlaygroundsContentRecord = (
         0x706c6179, /* 'play' */
         0,
         { outValue, type, hint, _ in
@@ -323,7 +323,7 @@ struct PlaygroundMacroExpansionTests {
       @_used
       #endif
       @available(*, deprecated, message: "This property is an implementation detail of the playgrounds library. Do not use it directly.")
-      private let __macro_local_23PlaygroundContentRecordfMu_: Playgrounds.__PlaygroundsContentRecord = (
+      nonisolated private let __macro_local_23PlaygroundContentRecordfMu_: Playgrounds.__PlaygroundsContentRecord = (
         0x706c6179, /* 'play' */
         0,
         { outValue, type, hint, _ in
@@ -405,7 +405,7 @@ struct PlaygroundMacroExpansionTests {
       @_used
       #endif
       @available(*, deprecated, message: "This property is an implementation detail of the playgrounds library. Do not use it directly.")
-      private let __macro_local_23PlaygroundContentRecordfMu_: Playgrounds.__PlaygroundsContentRecord = (
+      nonisolated private let __macro_local_23PlaygroundContentRecordfMu_: Playgrounds.__PlaygroundsContentRecord = (
         0x706c6179, /* 'play' */
         0,
         { outValue, type, hint, _ in
@@ -487,7 +487,7 @@ struct PlaygroundMacroExpansionTests {
       @_used
       #endif
       @available(*, deprecated, message: "This property is an implementation detail of the playgrounds library. Do not use it directly.")
-      private let __macro_local_23PlaygroundContentRecordfMu_: Playgrounds.__PlaygroundsContentRecord = (
+      nonisolated private let __macro_local_23PlaygroundContentRecordfMu_: Playgrounds.__PlaygroundsContentRecord = (
         0x706c6179, /* 'play' */
         0,
         { outValue, type, hint, _ in
@@ -557,7 +557,7 @@ struct PlaygroundMacroExpansionTests {
       @_used
       #endif
       @available(*, deprecated, message: "This property is an implementation detail of the playgrounds library. Do not use it directly.")
-      private let __macro_local_23PlaygroundContentRecordfMu_: Playgrounds.__PlaygroundsContentRecord = (
+      nonisolated private let __macro_local_23PlaygroundContentRecordfMu_: Playgrounds.__PlaygroundsContentRecord = (
         0x706c6179, /* 'play' */
         0,
         { outValue, type, hint, _ in
@@ -627,7 +627,7 @@ struct PlaygroundMacroExpansionTests {
       @_used
       #endif
       @available(*, deprecated, message: "This property is an implementation detail of the playgrounds library. Do not use it directly.")
-      private let __macro_local_23PlaygroundContentRecordfMu_: Playgrounds.__PlaygroundsContentRecord = (
+      nonisolated private let __macro_local_23PlaygroundContentRecordfMu_: Playgrounds.__PlaygroundsContentRecord = (
         0x706c6179, /* 'play' */
         0,
         { outValue, type, hint, _ in


### PR DESCRIPTION
rdar://156447945