### PR TITLE
Fixes @_section warning with Swift 6.3.

### DIFF
--- a/Sources/Playgrounds/Discoverable/PlaygroundContent+Discoverable.swift
+++ b/Sources/Playgrounds/Discoverable/PlaygroundContent+Discoverable.swift
@@ -122,7 +122,7 @@ public typealias __PlaygroundsContentRecordAccessor = @convention(c) (
 public typealias __PlaygroundsContentRecord = (
   kind: UInt32,
   reserved1: UInt32,
-  accessor: __PlaygroundsContentRecordAccessor?,
+  accessor: __PlaygroundsContentRecordAccessor,
   context: UInt,
   reserved2: UInt
 )

--- a/Tests/PlaygroundMacrosTests/PlaygroundMacroExpansionTests.swift
+++ b/Tests/PlaygroundMacrosTests/PlaygroundMacroExpansionTests.swift
@@ -27,6 +27,34 @@ fileprivate let macroExpansionTestSupported = false
 @Suite("Playground Macro Expansion Tests")
 struct PlaygroundMacroExpansionTests {
 
+  private var sectionExpansion: String {
+#if compiler(>=6.3)
+      """
+      #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
+      @section("__DATA_CONST,__swift5_tests")
+      #elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android) || os(WASI)
+      @section("swift5_tests")
+      #elseif os(Windows)
+      @section(".sw5test$B")
+      #endif
+      @used
+      """
+#else
+      """
+      #if hasFeature(SymbolLinkageMarkers)
+      #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
+      @_section("__DATA_CONST,__swift5_tests")
+      #elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android) || os(WASI)
+      @_section("swift5_tests")
+      #elseif os(Windows)
+      @_section(".sw5test$B")
+      #endif
+      @_used
+      #endif
+      """
+#endif
+  }
+
   @Test("Named Playground with trailing closure expansion",
         .enabled(if: macroExpansionTestSupported))
   func namedPlaygroundWithTrailingClosureExpansionTest() throws {
@@ -66,16 +94,7 @@ struct PlaygroundMacroExpansionTests {
       }
       
       }
-      #if hasFeature(SymbolLinkageMarkers)
-      #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
-      @_section("__DATA_CONST,__swift5_tests")
-      #elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android) || os(WASI)
-      @_section("swift5_tests")
-      #elseif os(Windows)
-      @_section(".sw5test$B")
-      #endif
-      @_used
-      #endif
+      \(sectionExpansion)
       @available(*, deprecated, message: "This property is an implementation detail of the playgrounds library. Do not use it directly.")
       nonisolated private let __macro_local_23PlaygroundContentRecordfMu_: Playgrounds.__PlaygroundsContentRecord = (
         0x706c6179, /* 'play' */
@@ -148,16 +167,7 @@ struct PlaygroundMacroExpansionTests {
       }
       
       }
-      #if hasFeature(SymbolLinkageMarkers)
-      #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
-      @_section("__DATA_CONST,__swift5_tests")
-      #elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android) || os(WASI)
-      @_section("swift5_tests")
-      #elseif os(Windows)
-      @_section(".sw5test$B")
-      #endif
-      @_used
-      #endif
+      \(sectionExpansion)
       @available(*, deprecated, message: "This property is an implementation detail of the playgrounds library. Do not use it directly.")
       nonisolated private let __macro_local_23PlaygroundContentRecordfMu_: Playgrounds.__PlaygroundsContentRecord = (
         0x706c6179, /* 'play' */
@@ -230,16 +240,7 @@ struct PlaygroundMacroExpansionTests {
       }
       
       }
-      #if hasFeature(SymbolLinkageMarkers)
-      #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
-      @_section("__DATA_CONST,__swift5_tests")
-      #elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android) || os(WASI)
-      @_section("swift5_tests")
-      #elseif os(Windows)
-      @_section(".sw5test$B")
-      #endif
-      @_used
-      #endif
+      \(sectionExpansion)
       @available(*, deprecated, message: "This property is an implementation detail of the playgrounds library. Do not use it directly.")
       nonisolated private let __macro_local_23PlaygroundContentRecordfMu_: Playgrounds.__PlaygroundsContentRecord = (
         0x706c6179, /* 'play' */
@@ -312,16 +313,7 @@ struct PlaygroundMacroExpansionTests {
       }
       
       }
-      #if hasFeature(SymbolLinkageMarkers)
-      #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
-      @_section("__DATA_CONST,__swift5_tests")
-      #elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android) || os(WASI)
-      @_section("swift5_tests")
-      #elseif os(Windows)
-      @_section(".sw5test$B")
-      #endif
-      @_used
-      #endif
+      \(sectionExpansion)
       @available(*, deprecated, message: "This property is an implementation detail of the playgrounds library. Do not use it directly.")
       nonisolated private let __macro_local_23PlaygroundContentRecordfMu_: Playgrounds.__PlaygroundsContentRecord = (
         0x706c6179, /* 'play' */
@@ -394,16 +386,7 @@ struct PlaygroundMacroExpansionTests {
       }
       
       }
-      #if hasFeature(SymbolLinkageMarkers)
-      #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
-      @_section("__DATA_CONST,__swift5_tests")
-      #elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android) || os(WASI)
-      @_section("swift5_tests")
-      #elseif os(Windows)
-      @_section(".sw5test$B")
-      #endif
-      @_used
-      #endif
+      \(sectionExpansion)
       @available(*, deprecated, message: "This property is an implementation detail of the playgrounds library. Do not use it directly.")
       nonisolated private let __macro_local_23PlaygroundContentRecordfMu_: Playgrounds.__PlaygroundsContentRecord = (
         0x706c6179, /* 'play' */
@@ -476,16 +459,7 @@ struct PlaygroundMacroExpansionTests {
       }
       
       }
-      #if hasFeature(SymbolLinkageMarkers)
-      #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
-      @_section("__DATA_CONST,__swift5_tests")
-      #elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android) || os(WASI)
-      @_section("swift5_tests")
-      #elseif os(Windows)
-      @_section(".sw5test$B")
-      #endif
-      @_used
-      #endif
+      \(sectionExpansion)
       @available(*, deprecated, message: "This property is an implementation detail of the playgrounds library. Do not use it directly.")
       nonisolated private let __macro_local_23PlaygroundContentRecordfMu_: Playgrounds.__PlaygroundsContentRecord = (
         0x706c6179, /* 'play' */
@@ -546,16 +520,7 @@ struct PlaygroundMacroExpansionTests {
       }
       
       }
-      #if hasFeature(SymbolLinkageMarkers)
-      #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
-      @_section("__DATA_CONST,__swift5_tests")
-      #elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android) || os(WASI)
-      @_section("swift5_tests")
-      #elseif os(Windows)
-      @_section(".sw5test$B")
-      #endif
-      @_used
-      #endif
+      \(sectionExpansion)
       @available(*, deprecated, message: "This property is an implementation detail of the playgrounds library. Do not use it directly.")
       nonisolated private let __macro_local_23PlaygroundContentRecordfMu_: Playgrounds.__PlaygroundsContentRecord = (
         0x706c6179, /* 'play' */
@@ -616,16 +581,7 @@ struct PlaygroundMacroExpansionTests {
       }
       
       }
-      #if hasFeature(SymbolLinkageMarkers)
-      #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
-      @_section("__DATA_CONST,__swift5_tests")
-      #elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android) || os(WASI)
-      @_section("swift5_tests")
-      #elseif os(Windows)
-      @_section(".sw5test$B")
-      #endif
-      @_used
-      #endif
+      \(sectionExpansion)
       @available(*, deprecated, message: "This property is an implementation detail of the playgrounds library. Do not use it directly.")
       nonisolated private let __macro_local_23PlaygroundContentRecordfMu_: Playgrounds.__PlaygroundsContentRecord = (
         0x706c6179, /* 'play' */


### PR DESCRIPTION
Uses the accepted-in-Swift 6.3 @section and @used attributes with Swift 6.3. Otherwise falls back to the underscored experimental feature attributes for older compilers.

Fixes #6.

rdar://170841492

