### PR TITLE
Remove "legacy" test content discovery path.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.3
 
 //
 // This source file is part of the Swift Play Experimental open source project

--- a/Sources/PlaygroundMacros/PlaygroundMacro.swift
+++ b/Sources/PlaygroundMacros/PlaygroundMacro.swift
@@ -85,38 +85,16 @@ public enum Playground: DeclarationMacro, Sendable {
     // The playground content record to be be looked up at runtime
     let playgroundContentRecordName = context.makeUniqueName("PlaygroundContentRecord")
     
-  #if compiler(>=6.3)
-    // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0492-section-control.md
-    let sectionDecl: DeclSyntax =
+    let playgroundContentRecordDecl: DeclSyntax =
       """
-      #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
+      #if objectFormat(MachO)
       @section("__DATA_CONST,__swift5_tests")
-      #elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android) || os(WASI)
+      #elseif objectFormat(ELF) || objectFormat(Wasm)
       @section("swift5_tests")
-      #elseif os(Windows)
+      #elseif objectFormat(COFF)
       @section(".sw5test$B")
       #endif
       @used
-      """
-  #else
-    let sectionDecl: DeclSyntax =
-      """
-      #if hasFeature(SymbolLinkageMarkers)
-      #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
-      @_section("__DATA_CONST,__swift5_tests")
-      #elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android) || os(WASI)
-      @_section("swift5_tests")
-      #elseif os(Windows)
-      @_section(".sw5test$B")
-      #endif
-      @_used
-      #endif
-      """
-  #endif
-
-    let playgroundContentRecordDecl: DeclSyntax =
-      """
-      \(sectionDecl)
       @available(*, deprecated, message: "This property is an implementation detail of the playgrounds library. Do not use it directly.")
       nonisolated private let \(playgroundContentRecordName): Playgrounds.__PlaygroundsContentRecord = (
         0x706c6179, /* 'play' */
@@ -135,25 +113,11 @@ public enum Playground: DeclarationMacro, Sendable {
         0,
         0
       )
-      
-      """
-
-    // The playground content record container to be looked up at runtime
-    let playgroundContentRecordContainerName = context.makeUniqueName("__🟡$PlaygroundContentRecordContainer")
-    let playgroundContentRecordContainerDecl: DeclSyntax =
-      """
-      @available(*, deprecated, message: "This type is an implementation detail of the playgrounds library. Do not use it directly.")
-      enum \(playgroundContentRecordContainerName): Playgrounds.__PlaygroundsContentRecordContainer {
-        nonisolated static var __playgroundsContentRecord: Playgrounds.__PlaygroundsContentRecord {
-          \(playgroundContentRecordName)
-        }
-      }
       """
 
     return [
       playgroundEntryContainerDecl,
       playgroundContentRecordDecl,
-      playgroundContentRecordContainerDecl
     ]
   }
   

--- a/Sources/Playgrounds/Discoverable/PlaygroundContent+Discoverable.swift
+++ b/Sources/Playgrounds/Discoverable/PlaygroundContent+Discoverable.swift
@@ -19,43 +19,15 @@ extension PlaygroundContent: DiscoverableAsTestContent {
   /// Use the hint type to avoid running code for _every_ playground in a binary
   /// in order to find the one that you care about.
   fileprivate typealias TestContentAccessorHint = Hint
-
-  /// This property acts as a hint to ``DiscoverableAsTestContent`` so that it
-  /// can skip over types whose names don't match the pattern used in the macro.
-  fileprivate static var _testContentTypeNameHint: String {
-    "__🟡$PlaygroundContentRecordContainer"
-  }
 }
 
 extension PlaygroundContent {
-  private static func allTypeMetadataBasedTestContentRecords() -> some Sequence<TestContentRecord<Self>> {
-    allTypeMetadataBasedTestContentRecords { type, outRecord in
-      guard let type = type as? any __PlaygroundsContentRecordContainer.Type else {
-        return false
-      }
-      outRecord.withMemoryRebound(to: __PlaygroundsContentRecord.self) { outRecord in
-        outRecord.baseAddress!.initialize(to: type.__playgroundsContentRecord)
-      }
-      return true
-    }
-  }
-
   /// All available playground instances in the process, according to the runtime.
   ///
   /// The order of values in this sequence is unspecified.
   static var all: some Sequence<Self> {
-    var result = [Self]()
-
-    result = PlaygroundContent.allTestContentRecords().compactMap {
-      $0.load()
-    }
-
-    if result.isEmpty {
-      // Fall back to type-based discovery.
-      result = PlaygroundContent.allTypeMetadataBasedTestContentRecords().compactMap {
-        $0.load()
-      }
-    }
+    let result = PlaygroundContent.allTestContentRecords().lazy
+      .compactMap { $0.load() }
 
     return Set(result)
   }
@@ -69,18 +41,9 @@ extension PlaygroundContent {
   /// Find the first playground in the current process with the given hint (name
   /// or ID.)
   static func find(withHint hint: Hint) -> Self? {
-    var result = PlaygroundContent.allTestContentRecords().lazy
+    PlaygroundContent.allTestContentRecords().lazy
       .compactMap { $0.load(withHint: hint) }
       .first
-
-    if result == nil {
-      // Fall back to type-based discovery.
-      result = PlaygroundContent.allTypeMetadataBasedTestContentRecords().lazy
-        .compactMap { $0.load(withHint: hint) }
-        .first
-    }
-
-    return result
   }
 }
 
@@ -187,22 +150,4 @@ public func __store(
     )
   )
   return true
-}
-
-// MARK: - Content Records (Type-Based Discovery) -
-
-/// A protocol describing a type that contains a playground.
-///
-/// - Warning: This protocol is used to implement the `#Playground` macro. Do
-///   not use it it directly.
-#if !os(Windows)
-@_weakLinked
-#endif
-@_alwaysEmitConformanceMetadata
-public protocol __PlaygroundsContentRecordContainer {
-  /// The playgrounds content record associated with this container.
-  ///
-  /// - Warning: This property is used to implement the `#Playground` macro. Do
-  ///   not use it it directly.
-  nonisolated static var __playgroundsContentRecord: __PlaygroundsContentRecord { get }
 }

--- a/Tests/PlaygroundMacrosTests/PlaygroundMacroExpansionTests.swift
+++ b/Tests/PlaygroundMacrosTests/PlaygroundMacroExpansionTests.swift
@@ -28,31 +28,16 @@ fileprivate let macroExpansionTestSupported = false
 struct PlaygroundMacroExpansionTests {
 
   private var sectionExpansion: String {
-#if compiler(>=6.3)
       """
-      #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
+      #if objectFormat(MachO)
       @section("__DATA_CONST,__swift5_tests")
-      #elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android) || os(WASI)
+      #elseif objectFormat(ELF) || objectFormat(Wasm)
       @section("swift5_tests")
-      #elseif os(Windows)
+      #elseif objectFormat(COFF)
       @section(".sw5test$B")
       #endif
       @used
       """
-#else
-      """
-      #if hasFeature(SymbolLinkageMarkers)
-      #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
-      @_section("__DATA_CONST,__swift5_tests")
-      #elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android) || os(WASI)
-      @_section("swift5_tests")
-      #elseif os(Windows)
-      @_section(".sw5test$B")
-      #endif
-      @_used
-      #endif
-      """
-#endif
   }
 
   @Test("Named Playground with trailing closure expansion",
@@ -113,12 +98,6 @@ struct PlaygroundMacroExpansionTests {
         0,
         0
       )
-      @available(*, deprecated, message: "This type is an implementation detail of the playgrounds library. Do not use it directly.")
-      enum __macro_local_36__🟡$PlaygroundContentRecordContainerfMu_: Playgrounds.__PlaygroundsContentRecordContainer {
-        nonisolated static var __playgroundsContentRecord: Playgrounds.__PlaygroundsContentRecord {
-          __macro_local_23PlaygroundContentRecordfMu_
-        }
-      }
       """,
       macroSpecs: ["Playground" : MacroSpec(type: Playground.self, conformances: [])]
     )
@@ -186,12 +165,6 @@ struct PlaygroundMacroExpansionTests {
         0,
         0
       )
-      @available(*, deprecated, message: "This type is an implementation detail of the playgrounds library. Do not use it directly.")
-      enum __macro_local_36__🟡$PlaygroundContentRecordContainerfMu_: Playgrounds.__PlaygroundsContentRecordContainer {
-        nonisolated static var __playgroundsContentRecord: Playgrounds.__PlaygroundsContentRecord {
-          __macro_local_23PlaygroundContentRecordfMu_
-        }
-      }
       """,
       macroSpecs: ["Playground" : MacroSpec(type: Playground.self, conformances: [])]
     )
@@ -259,12 +232,6 @@ struct PlaygroundMacroExpansionTests {
         0,
         0
       )
-      @available(*, deprecated, message: "This type is an implementation detail of the playgrounds library. Do not use it directly.")
-      enum __macro_local_36__🟡$PlaygroundContentRecordContainerfMu_: Playgrounds.__PlaygroundsContentRecordContainer {
-        nonisolated static var __playgroundsContentRecord: Playgrounds.__PlaygroundsContentRecord {
-          __macro_local_23PlaygroundContentRecordfMu_
-        }
-      }
       """,
       macroSpecs: ["Playground" : MacroSpec(type: Playground.self, conformances: [])]
     )
@@ -332,12 +299,6 @@ struct PlaygroundMacroExpansionTests {
         0,
         0
       )
-      @available(*, deprecated, message: "This type is an implementation detail of the playgrounds library. Do not use it directly.")
-      enum __macro_local_36__🟡$PlaygroundContentRecordContainerfMu_: Playgrounds.__PlaygroundsContentRecordContainer {
-        nonisolated static var __playgroundsContentRecord: Playgrounds.__PlaygroundsContentRecord {
-          __macro_local_23PlaygroundContentRecordfMu_
-        }
-      }
       """,
       macroSpecs: ["Playground" : MacroSpec(type: Playground.self, conformances: [])]
     )
@@ -405,12 +366,6 @@ struct PlaygroundMacroExpansionTests {
         0,
         0
       )
-      @available(*, deprecated, message: "This type is an implementation detail of the playgrounds library. Do not use it directly.")
-      enum __macro_local_36__🟡$PlaygroundContentRecordContainerfMu_: Playgrounds.__PlaygroundsContentRecordContainer {
-        nonisolated static var __playgroundsContentRecord: Playgrounds.__PlaygroundsContentRecord {
-          __macro_local_23PlaygroundContentRecordfMu_
-        }
-      }
       """,
       macroSpecs: ["Playground" : MacroSpec(type: Playground.self, conformances: [])]
     )
@@ -478,12 +433,6 @@ struct PlaygroundMacroExpansionTests {
         0,
         0
       )
-      @available(*, deprecated, message: "This type is an implementation detail of the playgrounds library. Do not use it directly.")
-      enum __macro_local_36__🟡$PlaygroundContentRecordContainerfMu_: Playgrounds.__PlaygroundsContentRecordContainer {
-        nonisolated static var __playgroundsContentRecord: Playgrounds.__PlaygroundsContentRecord {
-          __macro_local_23PlaygroundContentRecordfMu_
-        }
-      }
       """,
       macroSpecs: ["Playground" : MacroSpec(type: Playground.self, conformances: [])]
     )
@@ -539,12 +488,6 @@ struct PlaygroundMacroExpansionTests {
         0,
         0
       )
-      @available(*, deprecated, message: "This type is an implementation detail of the playgrounds library. Do not use it directly.")
-      enum __macro_local_36__🟡$PlaygroundContentRecordContainerfMu_: Playgrounds.__PlaygroundsContentRecordContainer {
-        nonisolated static var __playgroundsContentRecord: Playgrounds.__PlaygroundsContentRecord {
-          __macro_local_23PlaygroundContentRecordfMu_
-        }
-      }
       """,
       macroSpecs: ["Playground" : MacroSpec(type: Playground.self, conformances: [])]
     )
@@ -600,12 +543,6 @@ struct PlaygroundMacroExpansionTests {
         0,
         0
       )
-      @available(*, deprecated, message: "This type is an implementation detail of the playgrounds library. Do not use it directly.")
-      enum __macro_local_36__🟡$PlaygroundContentRecordContainerfMu_: Playgrounds.__PlaygroundsContentRecordContainer {
-        nonisolated static var __playgroundsContentRecord: Playgrounds.__PlaygroundsContentRecord {
-          __macro_local_23PlaygroundContentRecordfMu_
-        }
-      }
       """,
       macroSpecs: ["Playground" : MacroSpec(type: Playground.self, conformances: [])]
     )


### PR DESCRIPTION
This PR removes code around Swift Testing's "legacy" discovery path that uses Swift's type metadata section for discovery. Instead, Swift Testing now uses `@section` to store test content records.

This change necessitates bumping the minimum supported Swift toolchain version to 6.3. As of this writing, 6.3 is still in its prerelease phase, so we should hold off on merging this PR until it's released officially.

Resolves #5.